### PR TITLE
ci: invoke pytest as python -m pytest

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests
+          python -m pytest tests
         # or use:
         # python -m unittest discover tests
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests
+          python -m pytest tests
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Unblocks #227 deploy. `pytest tests` from repo root doesn't add cwd to sys.path, so the new tests in #226 (`tests/test_bigquery_upsert.py`, `tests/test_worker_scheduler.py`) hit ModuleNotFoundError on `import app.*`. `python -m pytest` prepends cwd, which is the standard fix. Run that failed: https://github.com/bercerita23/Kira_backend/actions/runs/25090766379