### PR TITLE
Deploy: redis-removal (retry with CI fix)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests
+          python -m pytest tests
         # or use:
         # python -m unittest discover tests
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests
+          python -m pytest tests
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Re-promotes APScheduler migration to prod. Includes the CI fix from #228 on top of the original #227 deploy that failed due to pytest sys.path.